### PR TITLE
v0.1.2

### DIFF
--- a/src/napari_apr_viewer/_APRViewer.py
+++ b/src/napari_apr_viewer/_APRViewer.py
@@ -56,7 +56,7 @@ class APRViewer(QWidget):
     def _changeMode(self, mode: [int, str]):
         mode = mode if isinstance(mode, str) else self.modes[mode]
         for layer in self.viewer.layers:
-            if isinstance(layer.data, pyapr.APRSlicer):
+            if isinstance(layer.data, pyapr.APRSlicer) and isinstance(layer, napari.layers.Image):
                 # set reconstruction mode
                 layer.data.mode = mode
 

--- a/src/napari_apr_viewer/_convert_image_to_apr.py
+++ b/src/napari_apr_viewer/_convert_image_to_apr.py
@@ -22,9 +22,11 @@ class DTypes(Enum):
                                      '(e.g. to compute the signal gradient). Higher values mean more '
                                      'smoothing, while 0 corresponds to no smoothing. Typical range: 0-10. '},
                intensity_threshold={'tooltip': 'The image gradient is set to 0 in regions of lower intensity '
-                                               'than this threshold.'},
-               sigma_threshold={'tooltip': 'The \"local intensity scale\" is clipped from below to this value. '},
-               grad_threshold={'tooltip': 'Gradient values below this value are set to 0.'},
+                                               'than this threshold.', 'min': 0, 'max': 65535},
+               sigma_threshold={'tooltip': 'The \"local intensity scale\" is clipped from below to this value. ',
+                                'min': 0, 'max': 65535},
+               grad_threshold={'tooltip': 'Gradient values below this value are set to 0.',
+                               'min': 0, 'max': 65535},
                auto_find_sigma_and_grad_threshold={'tooltip': 'Automatically compute \'sigma_threshold\' and '
                                                               '\'grad_threshold\' using Li thresholding on the '
                                                               'local intensity scale and gradient. Regions where '


### PR DESCRIPTION
set ranges for some parameters in `convert_image_to_apr` (previously these were limited to 0-1000)

fix bug where APR 'labels' layers output by the reader did not display correctly at coarse resolutions

modify the `view mode` of `APRViewer` to ignore 'labels' layers